### PR TITLE
Add wrapper.expand function

### DIFF
--- a/src/main/java/com/readmill/api/ReadmillWrapper.java
+++ b/src/main/java/com/readmill/api/ReadmillWrapper.java
@@ -411,6 +411,23 @@ public class ReadmillWrapper {
     return execute(request, HttpDelete.class);
   }
 
+  /**
+   * Expands a Request into a fully qualified URL.
+   * @param request Base request
+   * @return The resulting URI
+   */
+  public URI expand(Request request) {
+    if(mClientId != null) {
+      request.withParams("client_id", mClientId);
+    }
+
+    if(mToken != null) {
+      request.withParams("access_token", mToken.getAccessToken());
+    }
+
+    return URI.create(mEnv.getApiHost().toURI()).resolve(request.toUrl());
+  }
+
 
   /*
   * Protected

--- a/src/test/java/com/readmill/api/ReadmillWrapperTest.java
+++ b/src/test/java/com/readmill/api/ReadmillWrapperTest.java
@@ -270,6 +270,19 @@ public class ReadmillWrapperTest {
     assertThat(builder.getRequest().toUrl(), containsString("/endpoint"));
   }
 
+  @Test
+  public void expand() {
+    Token myToken = new Token("haxxess", "refreshorz", "*");
+    mWrapper.setToken(myToken);
+
+    Request request = Request.to("/users/1/avatar").withParams("size", "medium");
+
+    URI actual = mWrapper.expand(request);
+    URI expected = URI.create("https://api.example.com/v2/users/1/avatar?size=medium&client_id=my_client_id&access_token=haxxess");
+
+    assertThat(actual, is(expected));
+  }
+
   // Helpers
 
   private HttpClient stubbedHttpClient() {


### PR DESCRIPTION
For exanding a `Request` object into a fully qualified URI.
